### PR TITLE
Tilføjet passwordless authentication til ure

### DIFF
--- a/ChillChaser/Controllers/WatchController.cs
+++ b/ChillChaser/Controllers/WatchController.cs
@@ -1,0 +1,44 @@
+﻿using ChillChaser.Models.DB;
+using ChillChaser.Models.Request;
+using ChillChaser.Services;
+using Microsoft.AspNetCore.Authentication.BearerToken;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+
+namespace ChillChaser.Controllers {
+	[Route("api/[controller]")]
+	[ApiController]
+	public class WatchController(
+		IWatchAuthService watchAuthService, 
+		SignInManager<CCUser> signInManager,
+		UserManager<CCUser> userManager,
+		CCDbContext dbContext
+	) : ControllerBase {
+		private readonly IWatchAuthService _watchAuthService = watchAuthService;
+		private readonly SignInManager<CCUser> _signInManager = signInManager;
+		private readonly UserManager<CCUser> _userManager = userManager;
+		private readonly CCDbContext _ctx = dbContext;
+
+		[HttpPost("login", Name = "WatchLogin")]
+		public async Task<Results<Ok<AccessTokenResponse>, EmptyHttpResult, ProblemHttpResult>> StartWatchAuthSession(StartAuthSessionRequest body) {
+			var userId = await _watchAuthService.WaitForAuth(body.Token);
+			var user = await _ctx.Users.SingleAsync(u => u.Id == userId);
+			_signInManager.AuthenticationScheme = IdentityConstants.BearerScheme;
+			await _signInManager.SignInAsync(user, true);
+			return TypedResults.Empty;
+		}
+
+		[Authorize]
+		[HttpPost("authorize", Name = "WatchAuthorize")]
+		public async Task<IActionResult> AuthWatch(AuthorizeWatchRequest body) {
+			var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)
+						?? throw new Exception("No user id");
+			await _watchAuthService.GrantAccess(body.Token, userId);
+			return Ok();
+		}
+	}
+}

--- a/ChillChaser/Controllers/WatchController.cs
+++ b/ChillChaser/Controllers/WatchController.cs
@@ -1,4 +1,5 @@
 ﻿using ChillChaser.Models.DB;
+using ChillChaser.Models.Exceptions;
 using ChillChaser.Models.Request;
 using ChillChaser.Services;
 using Microsoft.AspNetCore.Authentication.BearerToken;
@@ -15,30 +16,38 @@ namespace ChillChaser.Controllers {
 	public class WatchController(
 		IWatchAuthService watchAuthService, 
 		SignInManager<CCUser> signInManager,
-		UserManager<CCUser> userManager,
 		CCDbContext dbContext
 	) : ControllerBase {
 		private readonly IWatchAuthService _watchAuthService = watchAuthService;
 		private readonly SignInManager<CCUser> _signInManager = signInManager;
-		private readonly UserManager<CCUser> _userManager = userManager;
 		private readonly CCDbContext _ctx = dbContext;
 
 		[HttpPost("login", Name = "WatchLogin")]
-		public async Task<Results<Ok<AccessTokenResponse>, EmptyHttpResult, ProblemHttpResult>> StartWatchAuthSession(StartAuthSessionRequest body) {
-			var userId = await _watchAuthService.WaitForAuth(body.Token);
-			var user = await _ctx.Users.SingleAsync(u => u.Id == userId);
-			_signInManager.AuthenticationScheme = IdentityConstants.BearerScheme;
-			await _signInManager.SignInAsync(user, true);
+		public async Task<Results<Ok<AccessTokenResponse>, EmptyHttpResult, BadRequest<string>, UnauthorizedHttpResult>> StartWatchAuthSession(StartAuthSessionRequest body) {
+			try {
+				var userId = await _watchAuthService.WaitForAuth(body.Token);
+				var user = await _ctx.Users.SingleAsync(u => u.Id == userId);
+				_signInManager.AuthenticationScheme = IdentityConstants.BearerScheme;
+				await _signInManager.SignInAsync(user, true);
+			} catch (WatchAuthSessionTimeoutException) {
+				return TypedResults.Unauthorized();
+			} catch (TokenAlreadyUsedException) {
+				return TypedResults.BadRequest("TokenAlreadyUsed");
+			}
 			return TypedResults.Empty;
 		}
 
 		[Authorize]
 		[HttpPost("authorize", Name = "WatchAuthorize")]
-		public async Task<IActionResult> AuthWatch(AuthorizeWatchRequest body) {
+		public async Task<Results<Ok, BadRequest<string>>> AuthWatch(AuthorizeWatchRequest body) {
 			var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)
 						?? throw new Exception("No user id");
-			await _watchAuthService.GrantAccess(body.Token, userId);
-			return Ok();
+			try {
+				await _watchAuthService.GrantAccess(body.Token, userId);
+			} catch (UnknownTokenException) {
+				return TypedResults.BadRequest("UnknownToken");
+			}
+			return TypedResults.Ok();
 		}
 	}
 }

--- a/ChillChaser/Models/Exceptions/TokenAlreadyUsedException.cs
+++ b/ChillChaser/Models/Exceptions/TokenAlreadyUsedException.cs
@@ -1,0 +1,6 @@
+﻿namespace ChillChaser.Models.Exceptions {
+	public class TokenAlreadyUsedException : Exception {
+		public TokenAlreadyUsedException(string? message) : base(message) {
+		}
+	}
+}

--- a/ChillChaser/Models/Exceptions/UnknownTokenException.cs
+++ b/ChillChaser/Models/Exceptions/UnknownTokenException.cs
@@ -1,0 +1,6 @@
+﻿namespace ChillChaser.Models.Exceptions {
+	public class UnknownTokenException : Exception {
+		public UnknownTokenException(string? message) : base(message) {
+		}
+	}
+}

--- a/ChillChaser/Models/Exceptions/WatchAuthSessionTimeout.cs
+++ b/ChillChaser/Models/Exceptions/WatchAuthSessionTimeout.cs
@@ -1,0 +1,6 @@
+﻿namespace ChillChaser.Models.Exceptions {
+	public class WatchAuthSessionTimeoutException : Exception {
+		public WatchAuthSessionTimeoutException(string? message) : base(message) {
+		}
+	}
+}

--- a/ChillChaser/Models/Internal/WatchAuthSession.cs
+++ b/ChillChaser/Models/Internal/WatchAuthSession.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Authentication.BearerToken;
+
+namespace ChillChaser.Models.Internal {
+	public class WatchAuthSession {
+		public required string Token { get; set; }
+		public required DateTime Expires { get; set; }
+		public required TaskCompletionSource<string> TaskCompletionSource { get; set; }
+	}
+}

--- a/ChillChaser/Models/Request/AuthorizeWatchRequest.cs
+++ b/ChillChaser/Models/Request/AuthorizeWatchRequest.cs
@@ -1,0 +1,5 @@
+﻿namespace ChillChaser.Models.Request {
+	public class AuthorizeWatchRequest {
+		public required string Token { get; set; }
+	}
+}

--- a/ChillChaser/Models/Request/StartAuthSessionRequest.cs
+++ b/ChillChaser/Models/Request/StartAuthSessionRequest.cs
@@ -1,0 +1,5 @@
+﻿namespace ChillChaser.Models.Request {
+	public class StartAuthSessionRequest {
+		public required string Token { get; set; }
+	}
+}

--- a/ChillChaser/Program.cs
+++ b/ChillChaser/Program.cs
@@ -77,6 +77,7 @@ builder.Services.AddTransient<IAppService, AppService>();
 builder.Services.AddTransient<INotificationService, NotificationService>();
 builder.Services.AddTransient<IAppUsageService, AppUsageService>();
 builder.Services.AddTransient<IHeartRateService, HeartRateService>();
+builder.Services.AddSingleton<IWatchAuthService, WatchAuthService>();
 
 var app = builder.Build();
 

--- a/ChillChaser/Services/IWatchAuthService.cs
+++ b/ChillChaser/Services/IWatchAuthService.cs
@@ -1,0 +1,8 @@
+﻿using ChillChaser.Models.DB;
+
+namespace ChillChaser.Services {
+	public interface IWatchAuthService {
+		public Task GrantAccess(string sessionToken, string userId);
+		public Task<string> WaitForAuth(string sessionToken);
+	}
+}

--- a/ChillChaser/Services/impl/WatchAuthService.cs
+++ b/ChillChaser/Services/impl/WatchAuthService.cs
@@ -1,0 +1,33 @@
+﻿using ChillChaser.Models.DB;
+using ChillChaser.Models.Exceptions;
+using ChillChaser.Models.Internal;
+using Microsoft.AspNetCore.Authentication.BearerToken;
+using Microsoft.AspNetCore.Identity;
+
+namespace ChillChaser.Services.impl {
+	public class WatchAuthService() : IWatchAuthService {
+		private readonly Dictionary<string, WatchAuthSession> _authSessions = new();
+		public async Task GrantAccess(string sessionToken, string userId) {
+			if (_authSessions.TryGetValue(sessionToken, out var was))
+				was.TaskCompletionSource.SetResult(userId);
+			_authSessions.Remove(sessionToken);
+		}
+
+		public async Task<string> WaitForAuth(string sessionToken) {
+				var taskCompletionSource = new TaskCompletionSource<string>();
+				try {
+					_authSessions.Add(sessionToken, new WatchAuthSession {
+						Token = sessionToken,
+						Expires = DateTime.Now.AddMinutes(10),
+						TaskCompletionSource = taskCompletionSource
+					});
+					return await taskCompletionSource.Task;
+				} catch (ArgumentException) {
+					throw new TokenAlreadyUsedException("Given token is already used");
+				} catch {
+					_authSessions.Remove(sessionToken);
+					throw;
+				}
+	}
+	}
+}

--- a/ChillChaser/Services/impl/WatchAuthService.cs
+++ b/ChillChaser/Services/impl/WatchAuthService.cs
@@ -14,20 +14,20 @@ namespace ChillChaser.Services.impl {
 		}
 
 		public async Task<string> WaitForAuth(string sessionToken) {
-				var taskCompletionSource = new TaskCompletionSource<string>();
-				try {
-					_authSessions.Add(sessionToken, new WatchAuthSession {
-						Token = sessionToken,
-						Expires = DateTime.Now.AddMinutes(10),
-						TaskCompletionSource = taskCompletionSource
-					});
-					return await taskCompletionSource.Task;
-				} catch (ArgumentException) {
-					throw new TokenAlreadyUsedException("Given token is already used");
-				} catch {
-					_authSessions.Remove(sessionToken);
-					throw;
-				}
-	}
+			var taskCompletionSource = new TaskCompletionSource<string>();
+			try {
+				_authSessions.Add(sessionToken, new WatchAuthSession {
+					Token = sessionToken,
+					Expires = DateTime.Now.AddMinutes(10),
+					TaskCompletionSource = taskCompletionSource
+				});
+				return await taskCompletionSource.Task;
+			} catch (ArgumentException) {
+				throw new TokenAlreadyUsedException("Given token is already used");
+			} catch {
+				_authSessions.Remove(sessionToken);
+				throw;
+			}
+		}
 	}
 }

--- a/E2ETest/Extensions.cs
+++ b/E2ETest/Extensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Principal;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace E2ETest {
+	public static class Extensions {
+		public static async Task<HttpResponseMessage> PostJsonWithBearer<T>(this HttpClient client, string url, string accessToken, T body) {
+			var content = JsonContent.Create(body);
+			HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, url);
+			message.Content = content;
+			message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+			return await client.SendAsync(message);
+		}
+
+		public static async Task<HttpResponseMessage> GetWithBearer(this HttpClient client, string url, string accessToken) {
+			var message = new HttpRequestMessage(HttpMethod.Get, url);
+			message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+			return await client.SendAsync(message);
+		}
+	}
+}

--- a/E2ETest/WatchAuthTest.cs
+++ b/E2ETest/WatchAuthTest.cs
@@ -1,0 +1,171 @@
+﻿using Microsoft.AspNetCore.Authentication.BearerToken;
+using Microsoft.AspNetCore.Identity.Data;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace E2ETest {
+	internal class AccountInfo {
+		public required string Email { get; set; }
+		public required string Password { get; set; }
+		public required string AccessToken { get; set; }
+	}
+
+	public class WatchAuthTest : IClassFixture<ClientFixture> {
+		private readonly ClientFixture _fixture;
+		private readonly HttpClient _client;
+
+		public WatchAuthTest(ClientFixture clientFixture) {
+			_fixture = clientFixture;
+			_client = _fixture.Client;
+		}
+
+		private async Task<AccountInfo> CreateAccount() {
+			var email = $"{RandomNumberGenerator.GetHexString(16)}@chillchaser.ovh";
+			var password = "abcABC1!";
+
+			await _fixture.Client.PostAsJsonAsync("/register", new {
+				email,
+				password
+			});
+
+			var loginResponse = await _fixture.Client.PostAsJsonAsync("/login", new {
+				email,
+				password
+			});
+
+			var accessToken = await loginResponse.Content.ReadFromJsonAsync<AccessTokenResponse>();
+
+			return new AccountInfo {
+				Email = email,
+				Password = password,
+				AccessToken = accessToken.AccessToken
+			};
+		}
+
+		private async Task<InfoResponse> GetInfo(string accessToken) {
+			var infoResponse = await _fixture.Client.GetWithBearer("/manage/info", accessToken);
+
+			return await infoResponse.Content.ReadFromJsonAsync<InfoResponse>();
+		}
+
+		[Fact(Timeout = 10000)]
+		public async Task AuthWatch_Simple() {
+			//Create account
+			var account = await CreateAccount();
+			var token = "abc123";
+
+			var loginTask = _fixture.Client.PostAsJsonAsync("/api/watch/login", new {
+				Token = token
+			});
+
+			await Task.Delay(250);
+
+			var authorizeResponse = await _fixture.Client.PostJsonWithBearer("/api/watch/authorize", account.AccessToken, new {
+				Token = token
+			});
+
+			var loginResponse = await loginTask;
+
+			var acquiredAccessToken = await loginResponse.Content.ReadFromJsonAsync<AccessTokenResponse>();
+
+			var info = await GetInfo(acquiredAccessToken.AccessToken);
+
+			Assert.Equal(HttpStatusCode.OK, authorizeResponse.StatusCode);
+			Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
+			Assert.NotNull(info);
+			Assert.Equal(account.Email, info.Email);
+		}
+
+		[Fact(Timeout = 10000)]
+		public async Task AuthWatch_duplicateToken() {
+			var account = await CreateAccount();
+			var token = "abc124";
+
+			var cancelationToken = new CancellationTokenSource();
+
+			var loginTask = _fixture.Client.PostAsJsonAsync("/api/watch/login", new {
+				Token = token
+			}, cancelationToken.Token);
+
+			await Task.Delay(250);
+
+			var duplicateResponse = await _fixture.Client.PostAsJsonAsync("/api/watch/login", new {
+				Token = token
+			});
+
+			await _fixture.Client.PostJsonWithBearer("/api/watch/authorize", account.AccessToken, new {
+				Token = token
+			});
+
+			var loginResponse = await loginTask;
+
+			var acquiredAccessToken = await loginResponse.Content.ReadFromJsonAsync<AccessTokenResponse>();
+
+			var info = await GetInfo(acquiredAccessToken.AccessToken);
+
+			Assert.Equal(HttpStatusCode.BadRequest, duplicateResponse.StatusCode);
+			Assert.Equal("\"TokenAlreadyUsed\"", await duplicateResponse.Content.ReadAsStringAsync());
+			Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
+			Assert.Equal(account.Email, info.Email);
+		}
+
+		[Fact(Timeout = 10000)]
+		public async Task AuthWatch_InvalidToken() {
+			var account = await CreateAccount();
+
+			var response = await _fixture.Client.PostJsonWithBearer("/api/watch/authorize", account.AccessToken, new {
+				Token = "bafarfe"
+			});
+			Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+			Assert.Equal("\"UnknownToken\"", await response.Content.ReadAsStringAsync());
+		}
+
+		[Fact(Timeout = 10000)]
+		public async Task AuthWatch_TokenGetsFreed() {
+			var account = await CreateAccount();
+			var account2 = await CreateAccount();
+			var token = "grlokgar";
+			var loginTask = _fixture.Client.PostAsJsonAsync("/api/watch/login", new {
+				Token = token
+			});
+
+			await Task.Delay(250);
+
+			await _fixture.Client.PostJsonWithBearer("/api/watch/authorize", account.AccessToken, new {
+				Token = token
+			});
+
+			var loginResponse = await loginTask;
+			var acquiredAccessToken = await loginResponse.Content.ReadFromJsonAsync<AccessTokenResponse>();
+
+			var loginTask2 = _fixture.Client.PostAsJsonAsync("/api/watch/login", new {
+				Token = token
+			});
+
+			await Task.Delay(250);
+
+			await _fixture.Client.PostJsonWithBearer("/api/watch/authorize", account2.AccessToken, new {
+				Token = token
+			});
+
+			var loginResponse2 = await loginTask2;
+			var acquiredAccessToken2 = await loginResponse2.Content.ReadFromJsonAsync<AccessTokenResponse>();
+
+			var info = await GetInfo(acquiredAccessToken.AccessToken);
+			var info2 = await GetInfo(acquiredAccessToken2.AccessToken);
+
+
+			Assert.Equal(account.Email, info.Email);
+			Assert.Equal(account2.Email, info2.Email);
+		}
+	}
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-name: chill-chaser-server
+name: chill-chaser-server-dev-env
 
 services: 
   db:


### PR DESCRIPTION
Tilføjede passwordless authentication som skal bruges til at logge et ur ind til en bestemt konto. Dette gøres via to forskellige endpoints. Den ene er login, som bruger long polling og returnere først når den givene token er blevet brugt af den bruger som allerede er logget ind. Den anden er authorize som tager en token og afslutter så den tilsvarende login request med den token. 

Så for at logge ind via denne metode skal man gøre følgende

1. Send post request til watch login endpointet med en token (bare en vilkårlig string) 
2. En bruger der er logget ind sender et post request til authorize endpointet med samme token som i trin 1
3. Login endpointet returnere efterfølgende en access og refresh token som kan bruges til ouath
4. ???
5. Profit

Konkret dokumentation af endpointsne er i swagger :D
 